### PR TITLE
feat: 지망 대학 수정 페이지 구현 및 UniversitySelectionStep 컴포넌트 개선

### DIFF
--- a/app/strategy-room/[seasonId]/applications/re-select-university/page.tsx
+++ b/app/strategy-room/[seasonId]/applications/re-select-university/page.tsx
@@ -1,68 +1,85 @@
 "use client";
 
-import { Suspense } from "react";
+import { Suspense, useEffect, useState } from "react";
 import { useParams } from "next/navigation";
 import Header from "@/components/layout/Header";
 import UniversitySelectionStep from "@/components/application/UniversitySelectionStep";
+import { getMyApplication } from "@/lib/api/slot";
+import { getSeasonSlots } from "@/lib/api/slot";
 import type { Slot } from "@/types/slot";
+import type { MyApplicationResponse } from "@/types/slot";
 
-// MOCK 데이터
-const MOCK_SLOTS: Slot[] = [
-  {
-    slotId: 1,
-    name: "University of California, Berkeley",
-    country: "미국",
-    duration: "1학기",
-    choiceCount: 45,
-    slotCount: "15명",
-  },
-  {
-    slotId: 2,
-    name: "University of Tokyo",
-    country: "일본",
-    duration: "1년",
-    choiceCount: 32,
-    slotCount: "10명",
-  },
-  {
-    slotId: 3,
-    name: "National University of Singapore",
-    country: "싱가포르",
-    duration: "1학기",
-    choiceCount: 28,
-    slotCount: "8명",
-  },
-  {
-    slotId: 4,
-    name: "University of Hong Kong",
-    country: "홍콩",
-    duration: "1학기",
-    choiceCount: 20,
-    slotCount: "6명",
-  },
-  {
-    slotId: 5,
-    name: "Peking University",
-    country: "중국",
-    duration: "1년",
-    choiceCount: 15,
-    slotCount: "12명",
-  },
-];
-
-const MOCK_INITIAL_SELECTIONS = [
-  { choice: 1, slot: MOCK_SLOTS[0] },
-  { choice: 2, slot: MOCK_SLOTS[1] },
-  { choice: 3, slot: MOCK_SLOTS[2] },
-];
-
-const MOCK_LANGUAGE_TEST = "TOEIC";
-const MOCK_LANGUAGE_SCORE = "920";
-const MOCK_EXTRA_SCORE = "0.3";
+interface SelectedUniversity {
+  choice: number;
+  slot: Slot;
+}
 
 function ApplicationEditContent() {
   const params = useParams();
   const seasonId = parseInt(params.seasonId as string);
+
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [myApplication, setMyApplication] = useState<MyApplicationResponse | null>(null);
+  const [slots, setSlots] = useState<Slot[]>([]);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setIsLoading(true);
+
+        const [myAppResult, slotsResult] = await Promise.all([
+          getMyApplication(seasonId),
+          getSeasonSlots(seasonId),
+        ]);
+
+        setMyApplication(myAppResult);
+        setSlots(slotsResult.slots);
+      } catch (err) {
+        console.error("Data fetch error:", err);
+        setError("데이터를 불러오는데 실패했습니다.");
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchData();
+  }, [seasonId]);
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen flex-col">
+        <Header title="지망 대학 변경하기" showPrevButton showHomeButton />
+        <div className="flex flex-1 items-center justify-center">
+          <p className="text-gray-500">로딩 중...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !myApplication) {
+    return (
+      <div className="flex min-h-screen flex-col">
+        <Header title="지망 대학 변경하기" showPrevButton showHomeButton />
+        <div className="flex flex-1 items-center justify-center">
+          <p className="text-red-500">{error || "데이터를 불러올 수 없습니다."}</p>
+        </div>
+      </div>
+    );
+  }
+
+  // MyApplicationResponse의 choices를 SelectedUniversity 형식으로 변환
+  const initialSelections: SelectedUniversity[] = myApplication.choices.map((choiceItem) => ({
+    choice: choiceItem.choice,
+    slot: {
+      slotId: choiceItem.slot.slotId,
+      name: choiceItem.slot.name,
+      country: choiceItem.slot.country,
+      choiceCount: choiceItem.slot.choiceCount,
+      slotCount: choiceItem.slot.slotCount,
+      duration: choiceItem.slot.duration,
+    },
+  }));
 
   return (
     <div className="flex min-h-screen flex-col">
@@ -70,15 +87,12 @@ function ApplicationEditContent() {
 
       <UniversitySelectionStep
         seasonId={seasonId}
-        gpaId={1} // MOCK
-        languageId={1} // MOCK
-        languageTest={MOCK_LANGUAGE_TEST}
-        languageScore={MOCK_LANGUAGE_SCORE}
-        languageGrade={null}
-        slots={MOCK_SLOTS}
+        languageTest={myApplication.language.testType}
+        languageScore={myApplication.language.score}
+        languageGrade={myApplication.language.grade}
+        slots={slots}
         mode="edit"
-        initialSelections={MOCK_INITIAL_SELECTIONS}
-        initialExtraScore={MOCK_EXTRA_SCORE}
+        initialSelections={initialSelections}
       />
     </div>
   );

--- a/app/strategy-room/[seasonId]/page.tsx
+++ b/app/strategy-room/[seasonId]/page.tsx
@@ -2,6 +2,7 @@
 
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useState, useMemo } from "react";
+import Link from "next/link";
 import Header from "@/components/layout/Header";
 import UniversitySlotCard from "@/components/strategy-room/UniversitySlotCard";
 import Tabs from "@/components/common/Tabs";
@@ -183,12 +184,12 @@ export default function StrategyRoomPage() {
         <div className="mt-[8px] flex items-center justify-between">
           <h2 className="head-4">{universityName} 교환학생</h2>
           {hasSharedGrade && (
-            <button
-              onClick={() => router.push(`/strategy-room/${seasonId}/applications/new`)}
-              className="rounded-[6px] bg-gray-100 px-[12px] py-[6px] text-[12px] text-gray-700 hover:bg-gray-200"
+            <Link
+              href={`/strategy-room/${seasonId}/applications/re-select-university`}
+              className="cursor-pointer rounded-full bg-gray-300 px-[12px] py-[6px] text-[12px]"
             >
               지원 대학교 변경
-            </button>
+            </Link>
           )}
         </div>
         <div className="relative mt-[12px] inline-block overflow-hidden rounded-full bg-gradient-to-r from-[#056DFF] via-[#029EFA] to-[#00D0FF] p-[1px]">


### PR DESCRIPTION
## #️⃣ Issue Number

<!-- 이슈 번호가 있다면 여기에 추가 -->
#60 
<br/>
<br/>

## 📝 요약(Summary)

지망 대학 수정 페이지를 구현하고, UniversitySelectionStep 컴포넌트를 신규 등록과 수정 모드에서 재사용할 수 있도록 개선했습니다.

### 주요 변경사항

1. **UniversitySelectionStep 컴포넌트 mode 기능 추가**
   - `mode` prop 추가: "new" (신규 등록) / "edit" (수정) 모드 지원
   - `gpaId`, `languageId`, `initialExtraScore`를 optional로 변경하여 edit 모드에서 유연하게 사용 가능
   - mode에 따른 UI 텍스트 자동 변경:
     - 타이틀: "지망 대학 등록하기" / "지망 대학 변경하기"
     - Step 표시: new 모드에서만 "Step 02" 표시
     - CTA 버튼: "완료하기" / "수정 완료하기"
     - 확인 모달: "지원서 제출" / "지망 대학 수정"
   - 성적 검증: new 모드에서만 gpaId, languageId 필수 체크
   - edit 모드에서는 지망 대학 수정 API 호출 준비 (TODO로 표시)

2. **지망 대학 수정 페이지 구현**
   - `/strategy-room/[seasonId]/applications/re-select-university` 경로에 수정 페이지 구현
   - `getMyApplication` API로 내 지원서 정보 가져오기
   - `getSeasonSlots` API로 전체 슬롯 목록 가져오기
   - 로딩 상태 및 에러 핸들링 추가
   - MyApplicationResponse의 choices를 SelectedUniversity 형식으로 변환하여 컴포넌트에 전달
   - UniversitySelectionStep 컴포넌트를 edit 모드로 재사용

3. **strategy-room 페이지 개선**
   - 지망 대학 변경하기 버튼 클릭 시 `/strategy-room/[seasonId]/applications/re-select-university`로 이동

### 왜 이렇게 수정했나요?

- **컴포넌트 재사용성**: UniversitySelectionStep을 mode 기반으로 재설계하여 신규 등록과 수정 기능 모두에서 사용할 수 있게 하여 코드 중복을 제거하고 유지보수성을 향상시켰습니다.
- **유연한 prop 설계**: edit 모드에서는 성적 정보(gpaId, languageId)가 필요 없으므로 optional로 만들어 컴포넌트를 더 유연하게 사용할 수 있도록 했습니다.
- **실제 데이터 사용**: MOCK 데이터 대신 `getMyApplication` API를 사용하여 실제 사용자의 지원서 정보를 불러와 수정할 수 있도록 구현했습니다.

<br/>
<br/>

## 🛠️ PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

<br/>
<br/>

**핵심 개념 (3줄 요약):**
- **컴포넌트 모드 패턴**: 하나의 컴포넌트에 mode prop을 추가하여 여러 상황(신규/수정)에서 재사용 가능하게 만드는 설계 패턴으로 코드 중복을 최소화
- **Optional Props**: TypeScript의 optional prop 기능을 활용하여 서로 다른 요구사항을 가진 모드에서 동일한 컴포넌트를 유연하게 사용
- **API 데이터 변환**: 백엔드 API 응답 형식을 프론트엔드 컴포넌트가 요구하는 형식으로 변환하여 컴포넌트 재사용성 확보

<br/>
<br/>