### PR TITLE
fix: ApplicantCard 어학성적 표시 로직 개선

### DIFF
--- a/components/strategy-room/ApplicantCard.tsx
+++ b/components/strategy-room/ApplicantCard.tsx
@@ -15,11 +15,9 @@ export default function ApplicantCard({ choice, onClick, isBlurred = false, isMe
   // 어학성적 표시 (languageTest languageGrade languageScore 형식)
   const languageDisplay = isBlurred
     ? "TOEFL 110"
-    : choice.languageTest && choice.languageGrade
+    : choice.languageTest
       ? [choice.languageTest, choice.languageGrade, choice.languageScore].filter(Boolean).join(" ")
-      : choice.languageTest
-        ? choice.languageTest
-        : "-";
+      : "-";
 
   // 환산점수 표시
   const scoreDisplay = isBlurred ? "95.50" : choice.score !== null ? choice.score.toFixed(2) : "-";


### PR DESCRIPTION
<!--- Pull Request title = 커밋 메시지와 동일 / 해당 이슈를 close 하지 않을 경우, footer #이슈 번호 제외  -->

## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->

<br/>
<br/>

## 📝 요약(Summary)
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
<!--- 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
languageGrade가 null인 경우(TOEIC 등)에도 languageScore가 올바르게 표시되도록 수정

- 기존: languageTest와 languageGrade가 둘 다 있을 때만 점수 표시
- 수정: languageTest가 있으면 grade/score 중 존재하는 값 모두 표시
- filter(Boolean)로 null 값 자동 제거하여 깔끔한 표시

예시:
- TOEIC (grade: null, score: "333") → "TOEIC 333"
- TOEFL (grade: "110", score: null) → "TOEFL 110"
<br/>
<br/>

## 🛠️ PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제