### PR TITLE
feat: add floating action button with context-aware navigation

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,14 +1,99 @@
 "use client";
 
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
 import Header from "@/components/layout/Header";
 import Footer from "@/components/layout/Footer";
 import HeroSection from "@/components/home/HeroSection";
 import FeatureSection from "@/components/home/FeatureSection";
 import StrategyRoomEntrances from "@/components/home/StrategyRoomEntrances";
 import HeaderAuthSection from "@/components/layout/HeaderAuthSection";
+import FloatingActionButton from "@/components/common/FloatingActionButton";
+import { useAuthStore } from "@/stores/authStore";
+import { getSeasons } from "@/lib/api/season";
+import { Season } from "@/types/season";
 
 export default function Home() {
-  // authStore가 자동으로 fetchUser()를 호출하므로 여기서는 불필요
+  const router = useRouter();
+  const { user, isLoggedIn } = useAuthStore();
+  const [seasons, setSeasons] = useState<Season[]>([]);
+  const [floatingButton, setFloatingButton] = useState<{
+    label: string;
+    action: () => void;
+  } | null>(null);
+  const [isButtonVisible, setIsButtonVisible] = useState(true);
+
+  // Fetch seasons
+  useEffect(() => {
+    const fetchSeasons = async () => {
+      try {
+        const data = await getSeasons();
+        setSeasons(data.seasons);
+      } catch (error) {
+        console.error("Failed to fetch seasons:", error);
+      }
+    };
+
+    fetchSeasons();
+  }, []);
+
+  // Set floating button based on user and seasons
+  useEffect(() => {
+    if (!isLoggedIn || !user || seasons.length === 0) {
+      setFloatingButton(null);
+      return;
+    }
+
+    // 1. 지원한 시즌이 있는지 확인
+    const appliedSeason = seasons.find((s) => s.hasApplied);
+    if (appliedSeason) {
+      setFloatingButton({
+        label: "우리 학교 실시간 경쟁률 바로가기",
+        action: () => router.push(`/strategy-room/${appliedSeason.seasonId}`),
+      });
+      return;
+    }
+
+    // 2. 본인 학교 시즌이 있는지 확인
+    const mySchoolSeason = seasons.find((s) => s.domesticUniversity === user.domesticUniversity);
+    if (mySchoolSeason && user.domesticUniversity) {
+      setFloatingButton({
+        label: "우리 학교 실시간 경쟁률 바로가기",
+        action: () => router.push(`/strategy-room/${mySchoolSeason.seasonId}`),
+      });
+      return;
+    }
+
+    // 3. 그 외: 탐색 유도
+    setFloatingButton({
+      label: "교환학생 모집 중인 대학 보기",
+      action: () => {
+        document.getElementById("strategy-room-entrances")?.scrollIntoView({
+          behavior: "smooth",
+        });
+      },
+    });
+  }, [user, isLoggedIn, seasons, router]);
+
+  // Handle scroll to fade out button when approaching StrategyRoomEntrances
+  useEffect(() => {
+    const handleScroll = () => {
+      const entrancesSection = document.getElementById("strategy-room-entrances");
+      if (!entrancesSection) return;
+
+      const rect = entrancesSection.getBoundingClientRect();
+      const threshold = window.innerHeight * 0.3; // 화면의 30% 지점
+
+      // StrategyRoomEntrances가 뷰포트 상단 30% 이내로 들어오면 fade-out
+      setIsButtonVisible(rect.top > threshold);
+    };
+
+    window.addEventListener("scroll", handleScroll);
+    handleScroll(); // 초기 상태 확인
+
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
+
   return (
     <div className="flex min-h-screen flex-col">
       <Header>
@@ -18,6 +103,14 @@ export default function Home() {
       <FeatureSection />
       <StrategyRoomEntrances />
       <Footer />
+
+      {floatingButton && (
+        <FloatingActionButton
+          label={floatingButton.label}
+          onClick={floatingButton.action}
+          isVisible={isButtonVisible}
+        />
+      )}
     </div>
   );
 }

--- a/components/common/FloatingActionButton.tsx
+++ b/components/common/FloatingActionButton.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import ShareIcon from "@/components/icons/ShareIcon";
+
+interface FloatingActionButtonProps {
+  label: string;
+  onClick: () => void;
+  isVisible: boolean;
+}
+
+export default function FloatingActionButton({ label, onClick, isVisible }: FloatingActionButtonProps) {
+  return (
+    <div
+      className={`fixed right-6 bottom-8 z-50 transition-all duration-300 ${
+        isVisible ? "opacity-100" : "pointer-events-none opacity-0"
+      }`}
+    >
+      {/* 툴팁 */}
+      <div className="absolute -top-[45px] right-0 z-10 whitespace-nowrap">
+        <div className="caption-2 inline-block rounded-md bg-black px-4 py-2 text-white">{label}</div>
+        <div className="absolute right-[20px] -bottom-[5px] h-0 w-0 border-t-8 border-r-8 border-l-8 border-t-black border-r-transparent border-l-transparent" />
+      </div>
+
+      {/* 버튼 */}
+      <button
+        onClick={onClick}
+        className="flex h-14 w-14 items-center justify-center rounded-full shadow-lg transition-all duration-200 hover:shadow-xl active:scale-95 cursor-pointer"
+        style={{
+          background: "linear-gradient(135deg, #00D0FF 0%, #029EFA 50%, #056DFF 100%)",
+        }}
+        aria-label={label}
+      >
+        <ShareIcon />
+      </button>
+    </div>
+  );
+}

--- a/components/home/StrategyRoomEntrances.tsx
+++ b/components/home/StrategyRoomEntrances.tsx
@@ -89,7 +89,10 @@ export default function StrategyRoomEntrances() {
   }
 
   return (
-    <div className="relative flex flex-col gap-[40px] px-[20px] pb-[100px]">
+    <div
+      id="strategy-room-entrances"
+      className="relative flex flex-col gap-[40px] px-[20px] pb-[100px]"
+    >
       <div className="flex flex-col items-center gap-[12px]">
         <p className="head-4">교환학생 모집 중인 대학</p>
         <p className="g-head-2 text-primary-blue">{seasons.length}개 대학</p>

--- a/components/icons/ShareIcon.tsx
+++ b/components/icons/ShareIcon.tsx
@@ -1,0 +1,66 @@
+interface ShareIconProps {
+  className?: string;
+  size?: number;
+}
+
+export default function ShareIcon({ className, size = 24 }: ShareIconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+    >
+      <g clipPath="url(#clip0_183_4423)">
+        <g filter="url(#filter0_d_183_4423)">
+          <path
+            d="M21.7071 2.29292C21.9787 2.56456 22.0707 2.96779 21.9438 3.33038L15.3605 22.14C14.9117 23.4223 13.1257 23.4951 12.574 22.2537L9.90437 16.2471L17.3676 7.33665C17.7595 6.86875 17.1312 6.24038 16.6633 6.63229L7.75272 14.0956L1.74631 11.426C0.504875 10.8743 0.57772 9.08834 1.85999 8.63954L20.6696 2.05617C21.0322 1.92926 21.4354 2.02128 21.7071 2.29292Z"
+            fill="white"
+          />
+        </g>
+      </g>
+      <defs>
+        <filter
+          id="filter0_d_183_4423"
+          x="-4.14453"
+          y="-3"
+          width="31.1445"
+          height="31.1445"
+          filterUnits="userSpaceOnUse"
+          colorInterpolationFilters="sRGB"
+        >
+          <feFlood floodOpacity="0" result="BackgroundImageFix" />
+          <feColorMatrix
+            in="SourceAlpha"
+            type="matrix"
+            values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+            result="hardAlpha"
+          />
+          <feOffset />
+          <feGaussianBlur stdDeviation="2.5" />
+          <feComposite in2="hardAlpha" operator="out" />
+          <feColorMatrix
+            type="matrix"
+            values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"
+          />
+          <feBlend
+            mode="normal"
+            in2="BackgroundImageFix"
+            result="effect1_dropShadow_183_4423"
+          />
+          <feBlend
+            mode="normal"
+            in="SourceGraphic"
+            in2="effect1_dropShadow_183_4423"
+            result="shape"
+          />
+        </filter>
+        <clipPath id="clip0_183_4423">
+          <rect width="24" height="24" fill="white" />
+        </clipPath>
+      </defs>
+    </svg>
+  );
+}


### PR DESCRIPTION
<!--- Pull Request title = 커밋 메시지와 동일 / 해당 이슈를 close 하지 않을 경우, footer #이슈 번호 제외  -->

## #️⃣ Issue Number
#106 
<!--- ex) #이슈번호, #이슈번호 -->

<br/>
<br/>

## 📝 요약(Summary)
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
<!--- 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
홈 화면에 사용자 상태에 따라 다른 동작을 하는 플로팅 버튼 추가:
- 지원한 시즌이 있으면 "실시간 경쟁률 보기"로 전략실 이동
- 본인 학교 시즌이 있으면 "내 학교 전략실 바로가기"
- 그 외에는 "교환 프로그램 둘러보기"로 스크롤

주요 변경사항:
- ShareIcon 컴포넌트 추가 (SVG to React component)
- FloatingActionButton 컴포넌트 생성 (그라데이션 배경, 툴팁 포함)
- StrategyRoomEntrances에 id 추가 (스크롤 타겟)
- 스크롤 위치에 따라 버튼 fade-out 처리
- 3가지 사용자 시나리오별 분기 로직 구현
<br/>
<br/>

## 🛠️ PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
