### PR TITLE
feat: 전략실 페이지에 Skeleton UI 추가로 Layout Shift 최소화

### DIFF
--- a/app/strategy-room/[seasonId]/page.tsx
+++ b/app/strategy-room/[seasonId]/page.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState, useMemo } from "react";
 import Link from "next/link";
 import Header from "@/components/layout/Header";
 import UniversitySlotCard from "@/components/strategy-room/UniversitySlotCard";
+import StrategyRoomPageSkeleton from "@/components/strategy-room/StrategyRoomPageSkeleton";
 import Tabs from "@/components/common/Tabs";
 import ShareGradeCTA from "@/components/strategy-room/ShareGradeCTA";
 import { getSeasonSlots, getMyApplication } from "@/lib/api/slot";
@@ -119,14 +120,7 @@ export default function StrategyRoomPage() {
   };
 
   if (isLoading) {
-    return (
-      <div className="flex min-h-screen flex-col">
-        <Header title="실시간 경쟁률" showHomeButton showPrevButton showBorder />
-        <div className="flex flex-1 items-center justify-center">
-          <p className="text-gray-500">로딩 중...</p>
-        </div>
-      </div>
-    );
+    return <StrategyRoomPageSkeleton />;
   }
 
   if (error || !data) {

--- a/app/strategy-room/[seasonId]/slots/[slotId]/page.tsx
+++ b/app/strategy-room/[seasonId]/slots/[slotId]/page.tsx
@@ -4,6 +4,7 @@ import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useState, useMemo, useRef } from "react";
 import Header from "@/components/layout/Header";
 import ApplicantCard from "@/components/strategy-room/ApplicantCard";
+import SlotDetailPageSkeleton from "@/components/strategy-room/SlotDetailPageSkeleton";
 import ShareGradeCTA from "@/components/strategy-room/ShareGradeCTA";
 import Tabs from "@/components/common/Tabs";
 import SchoolLogoWithFallback from "@/components/common/SchoolLogoWithFallback";
@@ -174,14 +175,7 @@ export default function SlotDetailPage() {
   }, [data, selectedTab]);
 
   if (isLoading) {
-    return (
-      <div className="flex min-h-screen flex-col">
-        <Header title="지원자 목록" showPrevButton showBorder />
-        <div className="flex flex-1 items-center justify-center">
-          <p className="text-gray-500">로딩 중...</p>
-        </div>
-      </div>
-    );
+    return <SlotDetailPageSkeleton />;
   }
 
   if (error || !data) {

--- a/components/common/SchoolLogoWithFallback.tsx
+++ b/components/common/SchoolLogoWithFallback.tsx
@@ -11,6 +11,7 @@ interface SchoolLogoWithFallbackProps {
   className?: string;
   fill?: boolean;
   sizes?: string;
+  isLoading?: boolean;
 }
 
 export default function SchoolLogoWithFallback({
@@ -21,8 +22,19 @@ export default function SchoolLogoWithFallback({
   className = "",
   fill = false,
   sizes,
+  isLoading = false,
 }: SchoolLogoWithFallbackProps) {
   const [imageError, setImageError] = useState(false);
+
+  // 로딩 중일 때 Skeleton 표시
+  if (isLoading) {
+    return (
+      <div
+        className={`animate-pulse rounded-full bg-gray-200 ${className}`}
+        style={{ width: width || "100%", height: height || "100%" }}
+      />
+    );
+  }
 
   // src에 프로토콜이 없으면 https:// 추가
   const imageSrc = src && !src.startsWith('http://') && !src.startsWith('https://') && !src.startsWith('//')

--- a/components/strategy-room/ApplicantCardSkeleton.tsx
+++ b/components/strategy-room/ApplicantCardSkeleton.tsx
@@ -1,0 +1,40 @@
+export default function ApplicantCardSkeleton() {
+  return (
+    <div className="flex cursor-default flex-col gap-[16px] rounded-[8px] bg-white p-[16px] shadow-[0_2px_8px_rgba(0,0,0,0.06)]">
+      {/* 닉네임 + ME 배지 공간 (subhead-3) */}
+      <div className="flex items-center gap-[8px]">
+        <div className="h-[20px] w-[80px] animate-pulse rounded bg-gray-200" />
+        {/* ME 배지는 조건부이므로 생략 */}
+      </div>
+
+      {/* 정보 그리드 - 실제와 동일한 구조 */}
+      <div className="grid grid-cols-2 gap-x-[24px] gap-y-[12px]">
+        {/* Row 1: 지망 / 환산점수 */}
+        <div className="flex items-center justify-between">
+          <span className="text-gray-700">지망</span>
+          <div className="h-[16px] w-[50px] animate-pulse rounded bg-gray-200" />
+        </div>
+        <div className="flex items-center justify-between">
+          <span className="text-gray-700">환산점수</span>
+          <div className="h-[16px] w-[60px] animate-pulse rounded bg-gray-200" />
+        </div>
+
+        {/* Row 2: 학점 / 어학성적 */}
+        <div className="flex items-center justify-between">
+          <span className="text-gray-700">학점</span>
+          <div className="h-[16px] w-[70px] animate-pulse rounded bg-gray-200" />
+        </div>
+        <div className="flex items-center justify-between">
+          <span className="text-gray-700">어학성적</span>
+          <div className="h-[16px] w-[80px] animate-pulse rounded bg-gray-200" />
+        </div>
+
+        {/* Row 3: 가산점 */}
+        <div className="flex items-center justify-between">
+          <span className="text-gray-700">가산점</span>
+          <div className="h-[16px] w-[50px] animate-pulse rounded bg-gray-200" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/strategy-room/SlotDetailPageSkeleton.tsx
+++ b/components/strategy-room/SlotDetailPageSkeleton.tsx
@@ -1,0 +1,82 @@
+import Header from "@/components/layout/Header";
+import ApplicantCardSkeleton from "@/components/strategy-room/ApplicantCardSkeleton";
+import SchoolLogoWithFallback from "@/components/common/SchoolLogoWithFallback";
+
+export default function SlotDetailPageSkeleton() {
+  return (
+    <div className="flex min-h-screen flex-col">
+      {/* 상단 헤더 - 실제와 동일 */}
+      <Header title="지원자 목록" showPrevButton showHomeButton />
+
+      {/* 대학 정보 섹션 - 실제 구조 기반 */}
+      <section className="border-b border-gray-100 p-[20px]">
+        {/* 학교 로고 */}
+        <div className="mb-[8px]">
+          <div className="relative h-[40px] w-[40px] overflow-hidden rounded-full">
+            <SchoolLogoWithFallback
+              src={null}
+              alt="로딩 중"
+              width={40}
+              height={40}
+              className="object-contain"
+              isLoading
+            />
+          </div>
+        </div>
+
+        {/* 학교 이름 (head-4) */}
+        <div className="mb-[8px] h-[24px] w-[180px] animate-pulse rounded bg-gray-200" />
+
+        {/* 홈페이지 버튼 (조건부이므로 일단 표시) */}
+        <div className="mb-[20px] inline-flex items-center gap-[4px] rounded-full bg-gray-300 px-[12px] py-[6px]">
+          <span className="inline-block h-[12px] w-[100px] animate-pulse rounded bg-gray-400" />
+        </div>
+
+        {/* 정보 목록 - 실제와 동일한 구조 */}
+        <div className="flex flex-col gap-[12px]">
+          <div className="flex items-center justify-between">
+            <span className="text-gray-700">국가</span>
+            <div className="h-[20px] w-[50px] animate-pulse rounded bg-gray-200" />
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="text-gray-700">지원자 수</span>
+            <div className="h-[20px] w-[40px] animate-pulse rounded bg-gray-200" />
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="text-gray-700">모집인원</span>
+            <div className="h-[20px] w-[40px] animate-pulse rounded bg-gray-200" />
+          </div>
+        </div>
+      </section>
+
+      {/* 지원자 목록 제목 - 실제 구조 기반 */}
+      <section className="px-[20px] py-[16px]">
+        {/* subhead-2 */}
+        <div className="h-[20px] w-[130px] animate-pulse rounded bg-gray-200" />
+        {/* 설명 텍스트 */}
+        <div className="mt-[4px] h-[16px] w-[220px] animate-pulse rounded bg-gray-200" />
+      </section>
+
+      {/* 탭 메뉴 - 실제 Tabs 컴포넌트 구조 기반 */}
+      <div className="relative flex border-b border-gray-200">
+        {["지망순위", "환산점수", "학점"].map((tab) => (
+          <div
+            key={tab}
+            className="medium-body-3 relative flex flex-1 flex-col items-center py-[12px] text-gray-700"
+          >
+            <span>{tab}</span>
+          </div>
+        ))}
+        {/* 탭 인디케이터 */}
+        <span className="absolute bottom-0 h-[2px] w-[33.33%] rounded-full bg-black" />
+      </div>
+
+      {/* 지원자 목록 - 실제와 동일한 padding */}
+      <div className="flex flex-1 flex-col gap-[10px] p-[20px] pb-[100px]">
+        {[1, 2, 3, 4, 5].map((i) => (
+          <ApplicantCardSkeleton key={i} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/strategy-room/StrategyRoomPageSkeleton.tsx
+++ b/components/strategy-room/StrategyRoomPageSkeleton.tsx
@@ -1,0 +1,62 @@
+import Header from "@/components/layout/Header";
+import UniversitySlotCardSkeleton from "@/components/strategy-room/UniversitySlotCardSkeleton";
+
+export default function StrategyRoomPageSkeleton() {
+  return (
+    <div className="flex min-h-screen flex-col">
+      {/* 상단 헤더 - 실제와 동일 */}
+      <Header
+        title="실시간 경쟁률"
+        showSearchButton
+        showPrevButton
+        showHomeButton
+      />
+
+      {/* 제목 섹션 - 실제 구조 기반 */}
+      <section className="px-[20px] py-[16px]">
+        {/* 학기 (caption-1) */}
+        <div className="h-[14px] w-[70px] animate-pulse rounded bg-gray-200" />
+
+        {/* 대학 이름 (head-4) + 변경 버튼 공간 */}
+        <div className="mt-[8px] flex items-center justify-between">
+          <div className="h-[24px] w-[160px] animate-pulse rounded bg-gray-200" />
+          {/* 버튼 공간 (조건부 렌더링이므로 비워둠) */}
+        </div>
+
+        {/* 참여자 수 배지 - 실제 크기 기반 */}
+        <div className="relative mt-[12px] inline-block overflow-hidden rounded-full bg-gradient-to-r from-[#056DFF] via-[#029EFA] to-[#00D0FF] p-[1px]">
+          <span className="caption-2 block rounded-full bg-[#E9F1FF] px-3 py-1">
+            <span className="inline-block h-[14px] w-[150px] animate-pulse rounded bg-gray-300" />
+          </span>
+        </div>
+      </section>
+
+      {/* 탭 메뉴 - 실제 Tabs 컴포넌트 구조 기반 */}
+      <div className="relative flex border-b border-gray-200">
+        {["지망한 대학", "지원자가 있는 대학", "모든 대학"].map((tab) => (
+          <div
+            key={tab}
+            className="medium-body-3 relative flex flex-1 flex-col items-center py-[12px] text-gray-700"
+          >
+            <span>{tab}</span>
+            <span className="mt-[2px] text-[12px]">
+              <span className="inline-block h-[12px] w-[20px] animate-pulse rounded bg-gray-200" />
+            </span>
+          </div>
+        ))}
+        {/* 탭 인디케이터 */}
+        <span
+          className="absolute bottom-0 h-[2px] w-[33.33%] rounded-full bg-black"
+          style={{ left: "33.33%" }}
+        />
+      </div>
+
+      {/* 대학 리스트 - 실제와 동일한 padding */}
+      <div className="relative flex flex-1 flex-col gap-[10px] p-[20px]">
+        {[1, 2, 3, 4, 5].map((i) => (
+          <UniversitySlotCardSkeleton key={i} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/strategy-room/UniversitySlotCardSkeleton.tsx
+++ b/components/strategy-room/UniversitySlotCardSkeleton.tsx
@@ -1,0 +1,46 @@
+import SchoolLogoWithFallback from "@/components/common/SchoolLogoWithFallback";
+
+export default function UniversitySlotCardSkeleton() {
+  return (
+    <div className="flex cursor-default flex-col items-end gap-[16px] rounded-[10px] border border-gray-100 p-[16px] shadow-[0_0_8px_rgba(0,0,0,0.06)]">
+      {/* 첫 번째 줄: 학교 로고 + 이름 / 국기 + 국가명 */}
+      <div className="flex w-full items-center justify-between">
+        <div className="flex items-center justify-center gap-[8px]">
+          {/* 학교 로고 (20x20) */}
+          <div className="relative h-[20px] w-[20px] overflow-hidden">
+            <SchoolLogoWithFallback
+              src={null}
+              alt="로딩 중"
+              width={20}
+              height={20}
+              className="object-contain"
+              isLoading
+            />
+          </div>
+          {/* 학교 이름 (subhead-3, max-w-[200px]) */}
+          <div className="h-[18px] w-[140px] animate-pulse rounded bg-gray-200" />
+        </div>
+        <div className="flex items-center gap-[4px]">
+          {/* 국기 (20x20) */}
+          <div className="h-[20px] w-[20px] animate-pulse rounded bg-gray-200" />
+          {/* 국가명 (caption-1) */}
+          <div className="h-[14px] w-[40px] animate-pulse rounded bg-gray-200" />
+        </div>
+      </div>
+
+      {/* 두 번째 줄: 지원자 수 / 모집인원 (w-[286px]) */}
+      <div className="flex w-[286px] justify-between">
+        <div className="flex w-[130px] justify-between">
+          <span className="caption-1 text-gray-700">지원자 수</span>
+          {/* medium-body-3 */}
+          <div className="h-[16px] w-[30px] animate-pulse rounded bg-gray-200" />
+        </div>
+        <div className="flex w-[130px] justify-between">
+          <span className="caption-1 text-gray-700">모집인원</span>
+          {/* medium-body-3 */}
+          <div className="h-[16px] w-[30px] animate-pulse rounded bg-gray-200" />
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 📝 요약(Summary)
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
<!--- 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
## 변경 사항

### Skeleton 컴포넌트 추가
- `StrategyRoomPageSkeleton`: 전략실 메인 페이지 로딩 UI
- `SlotDetailPageSkeleton`: 슬롯 상세 페이지 로딩 UI
- `UniversitySlotCardSkeleton`: 대학 슬롯 카드 로딩 UI
- `ApplicantCardSkeleton`: 지원자 카드 로딩 UI

### SchoolLogoWithFallback 개선
- `isLoading` props 추가로 로딩 상태 지원
- Skeleton과 실제 UI가 동일한 컴포넌트 사용으로 Layout Shift 제로화

### 페이지별 적용
- 경쟁률 메인 페이지: `isLoading` state로 Skeleton 표시
- 슬롯 상세 페이지: `isLoading` state로 Skeleton 표시
<br/>
<br/>

## 🛠️ PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
