### PR TITLE
fix: KST 시간 파싱 오류로 날짜가 하루 밀리는 문제 수정

### DIFF
--- a/lib/utils/date.ts
+++ b/lib/utils/date.ts
@@ -1,27 +1,55 @@
 /**
+ * 백엔드에서 받은 날짜 문자열을 KST 기준으로 파싱
+ * @param dateString - ISO 8601 형식의 날짜 문자열 (타임존 정보 있거나 없거나)
+ * @returns KST로 파싱된 Date 객체
+ */
+export const parseKstDate = (dateString: string): Date => {
+  // 이미 타임존 정보가 있는지 체크 (Z, +XX:XX, -XX:XX 형태)
+  const hasTimezone = /[+-]\d{2}:\d{2}|Z$/.test(dateString);
+
+  if (hasTimezone) {
+    // 타임존이 이미 있으면 그대로 파싱
+    return new Date(dateString);
+  }
+
+  // 타임존이 없으면 KST(+09:00)로 간주하여 파싱
+  return new Date(dateString + "+09:00");
+};
+
+/**
+ * KST 기준 자정(00:00:00)을 나타내는 Date 객체 반환 (환경 독립적)
+ * @param dateString - ISO 8601 형식의 날짜 문자열
+ * @returns KST 기준 자정의 UTC 타임스탬프를 가진 Date 객체
+ */
+export const getKstMidnight = (dateString: string): Date => {
+  const kstDate = parseKstDate(dateString);
+
+  // KST 시각으로 변환 (UTC 타임스탬프 + 9시간)
+  const KST_OFFSET_MS = 9 * 60 * 60 * 1000;
+  const kstTime = kstDate.getTime() + KST_OFFSET_MS;
+
+  // KST 기준 날짜 추출 (UTC 메서드로 읽음)
+  const temp = new Date(kstTime);
+  const year = temp.getUTCFullYear();
+  const month = temp.getUTCMonth();
+  const date = temp.getUTCDate();
+
+  // KST 자정을 UTC 타임스탬프로 변환하여 반환
+  return new Date(Date.UTC(year, month, date) - KST_OFFSET_MS);
+};
+
+/**
  * D-Day 계산 (목표 날짜까지 남은 일수) - 한국 시간(KST) 기준
  * @param dateString - ISO 8601 형식의 날짜 문자열
  * @returns 남은 일수 (음수일 경우 지난 일수)
  */
 export const calculateDDay = (dateString: string): number => {
-  const targetDate = new Date(dateString);
-  const today = new Date();
+  // KST 기준 자정으로 정규화 (환경 독립적)
+  const targetMidnight = getKstMidnight(dateString);
+  const todayMidnight = getKstMidnight(new Date().toISOString());
 
-  // 한국 시간(KST, UTC+9)으로 변환
-  const KST_OFFSET = 9 * 60; // 9시간을 분 단위로
-  const toKST = (date: Date) => {
-    const utcTime = date.getTime() + date.getTimezoneOffset() * 60000;
-    return new Date(utcTime + KST_OFFSET * 60000);
-  };
-
-  const targetKST = toKST(targetDate);
-  const todayKST = toKST(today);
-
-  // 시간 제거 (자정으로 설정)
-  targetKST.setHours(0, 0, 0, 0);
-  todayKST.setHours(0, 0, 0, 0);
-
-  const diffTime = targetKST.getTime() - todayKST.getTime();
+  // 두 자정 사이의 일수 차이 계산
+  const diffTime = targetMidnight.getTime() - todayMidnight.getTime();
   const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
   return diffDays;
 };
@@ -32,11 +60,14 @@ export const calculateDDay = (dateString: string): number => {
  * @returns yyyy.mm.dd 형식의 문자열
  */
 export const formatDate = (dateString: string): string => {
-  // 백엔드에서 KST 기준으로 보낸 날짜 문자열을 KST로 해석
-  // "2025-11-14T15:00:00" → KST 2025-11-14로 처리
-  const kstDate = new Date(dateString + "+09:00");
-  const year = kstDate.getFullYear();
-  const month = String(kstDate.getMonth() + 1).padStart(2, "0");
-  const day = String(kstDate.getDate()).padStart(2, "0");
+  // KST 기준 자정 기준으로 날짜 추출 (환경 독립적)
+  const midnight = getKstMidnight(dateString);
+
+  // UTC 메서드로 KST 날짜 추출 (KST 오프셋을 더해줌)
+  const KST_OFFSET_MS = 9 * 60 * 60 * 1000;
+  const midnightKst = new Date(midnight.getTime() + KST_OFFSET_MS);
+  const year = midnightKst.getUTCFullYear();
+  const month = String(midnightKst.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(midnightKst.getUTCDate()).padStart(2, "0");
   return `${year}.${month}.${day}`;
 };


### PR DESCRIPTION
## 📝 요약(Summary)
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
<!--- 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
백엔드에서 KST 기준으로 보낸 날짜 문자열(예: 2025-11-14T15:00:00)이
브라우저에서 로컬 타임존으로 해석되어 날짜가 하루 밀리는 문제를 해결했습니다.

변경사항:
- formatDate 함수에서 날짜 문자열에 +09:00 타임존을 명시적으로 추가
- 이를 통해 백엔드 KST 시간을 정확히 KST로 파싱하도록 수정
<br/>
<br/>

## 🛠️ PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
