### PR TITLE
feat: Toast 메시지 타입 구분 (error/info)

### DIFF
--- a/app/community/UniversityContent.tsx
+++ b/app/community/UniversityContent.tsx
@@ -26,7 +26,7 @@ export default function UniversityContent({ universities }: UniversityContentPro
   const [showFavoritesOnly, setShowFavoritesOnly] = useState(false);
   const [showFilledOnly, setShowFilledOnly] = useState(true);
   const { isLoggedIn } = useAuthStore();
-  const { errorMessage, isExiting, showError, hideToast } = useToast();
+  const { message, messageType, isExiting, showMessage, hideToast } = useToast();
 
   // 커스텀 훅으로 정렬/필터 관리
   const {
@@ -69,7 +69,7 @@ export default function UniversityContent({ universities }: UniversityContentPro
       setLocalUniversities((prev) =>
         prev.map((univ) => (univ.univId === univId ? { ...univ, isFavorite: prevState } : univ))
       );
-      showError("즐겨찾기 처리에 실패했습니다");
+      showMessage("즐겨찾기 처리에 실패했습니다", "error");
     }
   };
 
@@ -161,7 +161,7 @@ export default function UniversityContent({ universities }: UniversityContentPro
       )}
 
       {/* Toast */}
-      <Toast message={errorMessage} isExiting={isExiting} onClose={hideToast} />
+      <Toast message={message} type={messageType} isExiting={isExiting} onClose={hideToast} />
 
       {/* 하단 고정 즐겨찾기 필터 토글 */}
       {!isFilterOpen && <FavoriteFilterToggle checked={showFavoritesOnly} onChange={handleFavoriteFilterToggle} />}

--- a/app/strategy-room/[seasonId]/applications/new/page.tsx
+++ b/app/strategy-room/[seasonId]/applications/new/page.tsx
@@ -55,7 +55,7 @@ function ApplicationNewContent() {
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   // 폼 에러 핸들러
-  const { tooltipMessage, shouldShake, showError } = useFormErrorHandler();
+  const { tooltipMessage, shouldShake, showMessage } = useFormErrorHandler();
 
   // 초기 데이터 로드 및 hasApplied 확인
   useEffect(() => {
@@ -252,12 +252,12 @@ function ApplicationNewContent() {
   const handleSubmit = () => {
     // Validation
     if (!gpaId || !languageId) {
-      showError("성적 정보가 없습니다. Step 1부터 다시 진행해주세요.");
+      showMessage("성적 정보가 없습니다. Step 1부터 다시 진행해주세요.");
       return;
     }
 
     if (selectedUniversities.length === 0) {
-      showError("최소 1개 이상의 지망 대학을 선택해주세요.");
+      showMessage("최소 1개 이상의 지망 대학을 선택해주세요.");
       return;
     }
 
@@ -265,7 +265,7 @@ function ApplicationNewContent() {
     const sortedChoices = selectedUniversities.map((u) => u.choice).sort((a, b) => a - b);
     for (let i = 0; i < sortedChoices.length; i++) {
       if (sortedChoices[i] !== i + 1) {
-        showError("1지망부터 순서대로 채워주세요.");
+        showMessage("1지망부터 순서대로 채워주세요.");
         return;
       }
     }
@@ -278,14 +278,14 @@ function ApplicationNewContent() {
     // 보안: URL 조작으로 모달을 열었을 경우를 대비한 재검증
     if (!gpaId || !languageId) {
       submit.closeModal({ skipNavigation: true });
-      showError("성적 정보가 없습니다. 다시 입력해주세요.");
+      showMessage("성적 정보가 없습니다. 다시 입력해주세요.");
       router.replace(`/strategy-room/${seasonId}/applications/new?step=grade-registration`);
       return;
     }
 
     if (selectedUniversities.length === 0) {
       submit.closeModal({ skipNavigation: true });
-      showError("최소 1개 이상의 지망 대학을 선택해주세요.");
+      showMessage("최소 1개 이상의 지망 대학을 선택해주세요.");
       return;
     }
 
@@ -294,7 +294,7 @@ function ApplicationNewContent() {
     for (let i = 0; i < sortedChoices.length; i++) {
       if (sortedChoices[i] !== i + 1) {
         submit.closeModal({ skipNavigation: true });
-        showError("1지망부터 순서대로 채워주세요.");
+        showMessage("1지망부터 순서대로 채워주세요.");
         return;
       }
     }
@@ -331,7 +331,7 @@ function ApplicationNewContent() {
       router.push(`/strategy-room/${seasonId}`);
     } catch (error) {
       console.error("Application submission error:", error);
-      showError("지원서 제출에 실패했습니다. 다시 시도해주세요.");
+      showMessage("지원서 제출에 실패했습니다. 다시 시도해주세요.");
     } finally {
       setIsSubmitting(false);
     }

--- a/app/strategy-room/[seasonId]/applications/re-select-university/page.tsx
+++ b/app/strategy-room/[seasonId]/applications/re-select-university/page.tsx
@@ -38,7 +38,7 @@ function ApplicationEditContent() {
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   // 폼 에러 핸들러
-  const { tooltipMessage, shouldShake, showError } = useFormErrorHandler();
+  const { tooltipMessage, shouldShake, showMessage } = useFormErrorHandler();
 
   useEffect(() => {
     const fetchData = async () => {
@@ -144,7 +144,7 @@ function ApplicationEditContent() {
   const handleSubmit = () => {
     // Validation
     if (selectedUniversities.length === 0) {
-      showError("최소 1개 이상의 지망 대학을 선택해주세요.");
+      showMessage("최소 1개 이상의 지망 대학을 선택해주세요.");
       return;
     }
 
@@ -152,7 +152,7 @@ function ApplicationEditContent() {
     const sortedChoices = selectedUniversities.map((u) => u.choice).sort((a, b) => a - b);
     for (let i = 0; i < sortedChoices.length; i++) {
       if (sortedChoices[i] !== i + 1) {
-        showError("1지망부터 순서대로 채워주세요.");
+        showMessage("1지망부터 순서대로 채워주세요.");
         return;
       }
     }
@@ -165,7 +165,7 @@ function ApplicationEditContent() {
     // 보안: URL 조작으로 모달을 열었을 경우를 대비한 재검증
     if (selectedUniversities.length === 0) {
       confirm.closeModal();
-      showError("최소 1개 이상의 지망 대학을 선택해주세요.");
+      showMessage("최소 1개 이상의 지망 대학을 선택해주세요.");
       return;
     }
 
@@ -174,7 +174,7 @@ function ApplicationEditContent() {
     for (let i = 0; i < sortedChoices.length; i++) {
       if (sortedChoices[i] !== i + 1) {
         confirm.closeModal();
-        showError("1지망부터 순서대로 채워주세요.");
+        showMessage("1지망부터 순서대로 채워주세요.");
         return;
       }
     }
@@ -195,7 +195,7 @@ function ApplicationEditContent() {
       router.push(`/strategy-room/${seasonId}`);
     } catch (error) {
       console.error("Application update error:", error);
-      showError("지망 대학 수정에 실패했습니다. 다시 시도해주세요.");
+      showMessage("지망 대학 수정에 실패했습니다. 다시 시도해주세요.");
     } finally {
       setIsSubmitting(false);
     }

--- a/components/application/GradeRegistrationStep.tsx
+++ b/components/application/GradeRegistrationStep.tsx
@@ -44,7 +44,7 @@ const LANGUAGE_SCORE_RANGES: Record<string, { min: number; max: number }> = {
 };
 
 export default function GradeRegistrationStep({ existingGpa, existingLanguage, onSubmit }: GradeRegistrationStepProps) {
-  const { tooltipMessage, shouldShake, showError, clearError } = useFormErrorHandler();
+  const { tooltipMessage, shouldShake, showMessage, clearMessage } = useFormErrorHandler();
 
   // GPA 상태
   const [gpaScore, setGpaScore] = useState("");
@@ -84,35 +84,35 @@ export default function GradeRegistrationStep({ existingGpa, existingLanguage, o
 
   const handleSubmit = async () => {
     // 이전 에러 메시지 초기화
-    clearError();
+    clearMessage();
 
     // 학점 유효성 검사
     const gpaValue = parseFloat(gpaScore);
     if (!gpaScore || isNaN(gpaValue)) {
-      showError("학점을 입력해주세요.");
+      showMessage("학점을 입력해주세요.");
       return;
     }
 
     if (gpaValue < 0 || gpaValue > gpaCriteria) {
-      showError(`학점은 0 ~ ${gpaCriteria} 사이의 값이어야 합니다.`);
+      showMessage(`학점은 0 ~ ${gpaCriteria} 사이의 값이어야 합니다.`);
       return;
     }
 
     // 어학 시험 종류 검사
     if (!testType) {
-      showError("어학 시험 종류를 선택해주세요.");
+      showMessage("어학 시험 종류를 선택해주세요.");
       return;
     }
 
     // 어학 점수 검사
     if (testType === "기타") {
       if (!score) {
-        showError("어학 시험과 점수를 입력해주세요.");
+        showMessage("어학 시험과 점수를 입력해주세요.");
         return;
       }
     } else {
       if (!score) {
-        showError("점수를 입력해주세요.");
+        showMessage("점수를 입력해주세요.");
         return;
       }
 
@@ -122,12 +122,12 @@ export default function GradeRegistrationStep({ existingGpa, existingLanguage, o
 
       if (scoreRange) {
         if (isNaN(scoreValue)) {
-          showError("올바른 점수를 입력해주세요.");
+          showMessage("올바른 점수를 입력해주세요.");
           return;
         }
 
         if (scoreValue < scoreRange.min || scoreValue > scoreRange.max) {
-          showError(`${testType} 점수는 ${scoreRange.min} ~ ${scoreRange.max} 사이의 값이어야 합니다.`);
+          showMessage(`${testType} 점수는 ${scoreRange.min} ~ ${scoreRange.max} 사이의 값이어야 합니다.`);
           return;
         }
       }
@@ -177,7 +177,7 @@ export default function GradeRegistrationStep({ existingGpa, existingLanguage, o
       onSubmit(gpaResponse.gpaId, languageResponse.languageId);
     } catch (error) {
       console.error("Submit error:", error);
-      showError("성적 등록 중 오류가 발생했습니다.");
+      showMessage("성적 등록 중 오류가 발생했습니다.");
     } finally {
       setIsSubmitting(false);
     }

--- a/components/common/Toast.tsx
+++ b/components/common/Toast.tsx
@@ -1,18 +1,24 @@
 interface ToastProps {
   message: string | null;
+  type?: "error" | "info";
   isExiting?: boolean;
   onClose?: () => void;
 }
 
-export default function Toast({ message, isExiting = false, onClose }: ToastProps) {
+export default function Toast({ message, type = "error", isExiting = false, onClose }: ToastProps) {
   if (!message) return null;
+
+  // type에 따라 스타일 결정
+  // error: btn-secondary 스타일 (검정 배경)
+  // info: btn-primary 스타일 (파란 배경)
+  const bgStyle = type === "info" ? "bg-primary-blue" : "bg-black";
 
   return (
     <div
       className={`fixed top-[180px] left-1/2 z-50 -translate-x-1/2 cursor-pointer ${isExiting ? "animate-fade-out" : "animate-fade-in"}`}
       onClick={onClose}
     >
-      <div className="caption-2 rounded-md bg-black px-4 py-2 text-white">{message}</div>
+      <div className={`caption-2 rounded-md ${bgStyle} px-4 py-2 text-white`}>{message}</div>
     </div>
   );
 }

--- a/components/community/CommentItem.tsx
+++ b/components/community/CommentItem.tsx
@@ -41,7 +41,7 @@ export default function CommentItem({ comment, onRefetch, onOptimisticDelete }: 
   const [isDeleting, setIsDeleting] = useState(false);
   const deleteConfirmModal = useModalHistory({ modalKey: `comment-delete-${comment.commentId}` });
   const passwordModal = useModalHistory({ modalKey: `comment-password-${comment.commentId}` });
-  const { errorMessage, isExiting, showError, hideToast } = useToast();
+  const { message, messageType, isExiting, showMessage, hideToast } = useToast();
 
   const isAuthor = comment.author?.isAuthor === true;
   const isMemberComment = comment.author?.isMember === true;
@@ -66,13 +66,13 @@ export default function CommentItem({ comment, onRefetch, onOptimisticDelete }: 
     try {
       // 2. API 호출
       await deleteComment(comment.commentId);
-      showError("댓글이 삭제되었습니다.");
+      showMessage("댓글이 삭제되었습니다.", "info");
       // 3. 서버 데이터와 동기화
       await onRefetch();
     } catch (error) {
       // 4. 실패 시 refetch로 원복
       await onRefetch();
-      showError(error instanceof Error ? error.message : "삭제에 실패했습니다.");
+      showMessage(error instanceof Error ? error.message : "삭제에 실패했습니다.", "error");
     } finally {
       setIsDeleting(false);
     }
@@ -94,7 +94,7 @@ export default function CommentItem({ comment, onRefetch, onOptimisticDelete }: 
       // 2. API 호출
       await deleteComment(comment.commentId, password);
       passwordModal.closeModal();
-      showError("댓글이 삭제되었습니다.");
+      showMessage("댓글이 삭제되었습니다.", "info");
       // 3. 서버 데이터와 동기화
       await onRefetch();
     } catch (error) {
@@ -135,7 +135,7 @@ export default function CommentItem({ comment, onRefetch, onOptimisticDelete }: 
       </div>
 
       {/* Toast 메시지 */}
-      <Toast message={errorMessage} isExiting={isExiting} onClose={hideToast} />
+      <Toast message={message} type={messageType} isExiting={isExiting} onClose={hideToast} />
 
       {/* 삭제 확인 모달 (회원 본인 댓글) */}
       <ConfirmModal

--- a/components/community/PostActionMenu.tsx
+++ b/components/community/PostActionMenu.tsx
@@ -11,7 +11,7 @@ interface PostActionMenuProps {
   post: PostDetailResponse;
   onClose: () => void;
   onDelete: () => void;
-  showToast: (message: string, duration?: number) => void;
+  showToast: (message: string, type?: "error" | "info", duration?: number) => void;
 }
 
 /**
@@ -51,10 +51,10 @@ export default function PostActionMenu({ post, onClose, onDelete, showToast }: P
   const handleShare = async () => {
     try {
       await navigator.clipboard.writeText(window.location.href);
-      showToast("링크가 복사되었습니다!");
+      showToast("링크가 복사되었습니다!", "info");
       onClose();
     } catch (error) {
-      showToast("링크 복사에 실패했습니다.");
+      showToast("링크 복사에 실패했습니다.", "error");
     }
   };
 
@@ -70,12 +70,12 @@ export default function PostActionMenu({ post, onClose, onDelete, showToast }: P
     deleteConfirmModal.closeModal();
     try {
       await deletePost(post.postId);
-      showToast("게시글이 삭제되었습니다.");
+      showToast("게시글이 삭제되었습니다.", "info");
       setTimeout(() => {
         onDelete();
       }, 300);
     } catch (error) {
-      showToast(error instanceof Error ? error.message : "삭제에 실패했습니다.");
+      showToast(error instanceof Error ? error.message : "삭제에 실패했습니다.", "error");
     } finally {
       setIsDeleting(false);
     }
@@ -92,7 +92,7 @@ export default function PostActionMenu({ post, onClose, onDelete, showToast }: P
     try {
       await deletePost(post.postId, password);
       passwordModal.closeModal();
-      showToast("게시글이 삭제되었습니다.");
+      showToast("게시글이 삭제되었습니다.", "info");
       setTimeout(() => {
         onDelete();
       }, 300);
@@ -108,7 +108,7 @@ export default function PostActionMenu({ post, onClose, onDelete, showToast }: P
   const handleEdit = () => {
     if (!canEdit) return;
     // TODO: 게시글 수정 모달 열기
-    showToast("수정 기능은 추후 구현 예정입니다.");
+    showToast("수정 기능은 추후 구현 예정입니다.", "info");
     onClose();
   };
 

--- a/components/community/PostActionMenuButton.tsx
+++ b/components/community/PostActionMenuButton.tsx
@@ -28,7 +28,7 @@ interface PostActionMenuButtonProps {
 export default function PostActionMenuButton({ post }: PostActionMenuButtonProps) {
   const router = useRouter();
   const [showMenu, setShowMenu] = useState(false);
-  const { errorMessage, isExiting, showError, hideToast } = useToast();
+  const { message, messageType, isExiting, showMessage, hideToast } = useToast();
 
   return (
     <>
@@ -68,13 +68,13 @@ export default function PostActionMenuButton({ post }: PostActionMenuButtonProps
                 router.replace("/community");
               }
             }}
-            showToast={showError}
+            showToast={showMessage}
           />
         )}
       </div>
 
       {/* Toast 메시지 (메뉴와 독립적으로 표시) */}
-      <Toast message={errorMessage} isExiting={isExiting} onClose={hideToast} />
+      <Toast message={message} type={messageType} isExiting={isExiting} onClose={hideToast} />
     </>
   );
 }

--- a/components/community/PostDetailContent.tsx
+++ b/components/community/PostDetailContent.tsx
@@ -38,13 +38,13 @@ export default function PostDetailContent({ post }: PostDetailContentProps) {
   const [isLiked, setIsLiked] = useState(post.isLiked ?? false);
   const [likeCount, setLikeCount] = useState(post.likeCount ?? 0);
   const [isLikeLoading, setIsLikeLoading] = useState(false);
-  const { errorMessage, isExiting, showError, hideToast } = useToast();
+  const { message, messageType, isExiting, showMessage, hideToast } = useToast();
 
   // 좋아요 토글 (API 연동)
   const handleLikeToggle = async () => {
     // 로그인 여부 체크
     if (!isLoggedIn) {
-      showError("로그인 후 사용 가능합니다.");
+      showMessage("로그인 후 사용 가능합니다.", "error");
       return;
     }
 
@@ -70,7 +70,7 @@ export default function PostDetailContent({ post }: PostDetailContentProps) {
       // 에러 발생 시 이전 상태로 롤백
       setIsLiked(previousIsLiked);
       setLikeCount(previousLikeCount);
-      showError("좋아요 처리에 실패했습니다.");
+      showMessage("좋아요 처리에 실패했습니다.", "error");
     } finally {
       setIsLikeLoading(false);
     }
@@ -113,7 +113,7 @@ export default function PostDetailContent({ post }: PostDetailContentProps) {
       </article>
 
       {/* Toast 메시지 */}
-      <Toast message={errorMessage} isExiting={isExiting} onClose={hideToast} />
+      <Toast message={message} type={messageType} isExiting={isExiting} onClose={hideToast} />
     </>
   );
 }

--- a/hooks/useFormErrorHandler.ts
+++ b/hooks/useFormErrorHandler.ts
@@ -1,8 +1,8 @@
 import { useState, useRef, useEffect } from "react";
 
 /**
- * 폼 에러 처리 커스텀 훅
- * 에러 메시지 표시와 shake 애니메이션을 관리합니다.
+ * 폼 메시지 처리 커스텀 훅
+ * 메시지 표시와 shake 애니메이션을 관리합니다.
  * 메모리 누수 방지를 위해 타이머를 자동으로 cleanup 합니다.
  */
 export function useFormErrorHandler() {
@@ -22,12 +22,12 @@ export function useFormErrorHandler() {
   }, []);
 
   /**
-   * 에러 메시지를 표시하고 일정 시간 후 자동으로 숨깁니다.
+   * 메시지를 표시하고 일정 시간 후 자동으로 숨깁니다.
    * 이전 타이머가 있으면 취소하고 새로운 타이머를 시작합니다.
-   * @param message - 표시할 에러 메시지
+   * @param message - 표시할 메시지
    * @param duration - 메시지 표시 시간 (밀리초, 기본값: 2000ms)
    */
-  const showError = (message: string, duration = 2000) => {
+  const showMessage = (message: string, duration = 2000) => {
     // 이전 타이머가 있으면 취소
     if (timeoutRef.current) {
       clearTimeout(timeoutRef.current);
@@ -45,10 +45,10 @@ export function useFormErrorHandler() {
   };
 
   /**
-   * 에러 메시지와 shake 상태를 즉시 초기화합니다.
+   * 메시지와 shake 상태를 즉시 초기화합니다.
    * 진행 중인 타이머도 취소합니다.
    */
-  const clearError = () => {
+  const clearMessage = () => {
     // 진행 중인 타이머 취소
     if (timeoutRef.current) {
       clearTimeout(timeoutRef.current);
@@ -62,7 +62,7 @@ export function useFormErrorHandler() {
   return {
     tooltipMessage,
     shouldShake,
-    showError,
-    clearError,
+    showMessage,
+    clearMessage,
   };
 }

--- a/hooks/useToast.ts
+++ b/hooks/useToast.ts
@@ -1,12 +1,13 @@
 import { useState, useRef, useEffect } from "react";
 
 /**
- * Toast 에러 메시지 처리 커스텀 훅
- * 에러 메시지 표시와 자동 숨김을 관리합니다.
+ * Toast 메시지 처리 커스텀 훅
+ * 에러 메시지와 정보 메시지 표시 및 자동 숨김을 관리합니다.
  * 메모리 누수 방지를 위해 타이머를 자동으로 cleanup 합니다.
  */
 export function useToast() {
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+  const [messageType, setMessageType] = useState<"error" | "info">("error");
   const [isExiting, setIsExiting] = useState(false);
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
   const exitTimeoutRef = useRef<NodeJS.Timeout | null>(null);
@@ -26,12 +27,13 @@ export function useToast() {
   }, []);
 
   /**
-   * 에러 Toast를 표시하고 일정 시간 후 자동으로 숨깁니다.
+   * Toast 메시지를 표시하고 일정 시간 후 자동으로 숨깁니다.
    * 이전 타이머가 있으면 취소하고 새로운 타이머를 시작합니다.
-   * @param message - 표시할 에러 메시지
+   * @param msg - 표시할 메시지
+   * @param type - 메시지 타입 ("error" | "info", 기본값: "error")
    * @param duration - 메시지 표시 시간 (밀리초, 기본값: 1500ms)
    */
-  const showError = (message: string, duration = 1500) => {
+  const showMessage = (msg: string, type: "error" | "info" = "error", duration = 1500) => {
     // 이전 타이머가 있으면 취소
     if (timeoutRef.current) {
       clearTimeout(timeoutRef.current);
@@ -41,14 +43,15 @@ export function useToast() {
     }
 
     setIsExiting(false);
-    setErrorMessage(message);
+    setMessageType(type);
+    setMessage(msg);
 
     // fade-out 시작 타이머
     timeoutRef.current = setTimeout(() => {
       setIsExiting(true);
       // fade-out 애니메이션 후 제거
       exitTimeoutRef.current = setTimeout(() => {
-        setErrorMessage(null);
+        setMessage(null);
         setIsExiting(false);
         timeoutRef.current = null;
         exitTimeoutRef.current = null;
@@ -70,16 +73,17 @@ export function useToast() {
     setIsExiting(true);
     // fade-out 애니메이션 후 제거
     exitTimeoutRef.current = setTimeout(() => {
-      setErrorMessage(null);
+      setMessage(null);
       setIsExiting(false);
       exitTimeoutRef.current = null;
     }, 300);
   };
 
   return {
-    errorMessage,
+    message,
+    messageType,
     isExiting,
-    showError,
+    showMessage,
     hideToast,
   };
 }


### PR DESCRIPTION
## 📝 요약(Summary)
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
<!--- 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- showError/showInfo → showMessage(msg, type) 통일
- Toast 컴포넌트에 type prop 추가 (error=검정, info=파랑)
- 댓글/게시글 삭제 성공 등은 info 타입으로 표시

<br/>
<br/>

## 🛠️ PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
