### PR TITLE
feat: Header에 fallbackUrl 추가하여 직접 링크 접근 시 탐색 개선

### DIFF
--- a/app/community/country/[countryCode]/page.tsx
+++ b/app/community/country/[countryCode]/page.tsx
@@ -35,7 +35,7 @@ export default async function CountryDetailPage({ params }: CountryDetailPagePro
     <div className="flex min-h-screen flex-col">
       {/* Sticky Header */}
       <div className="sticky top-0 z-20 bg-white">
-        <Header showPrevButton showHomeButton>
+        <Header showPrevButton showHomeButton fallbackUrl="/community">
           <HeaderAuthSection />
         </Header>
       </div>

--- a/app/community/university/[univId]/page.tsx
+++ b/app/community/university/[univId]/page.tsx
@@ -57,7 +57,7 @@ export default async function UniversityDetailPage({ params }: UniversityDetailP
     <div className="flex min-h-screen flex-col">
       {/* Sticky Header */}
       <div className="sticky top-0 z-20 bg-white">
-        <Header showPrevButton showHomeButton>
+        <Header showPrevButton showHomeButton fallbackUrl="/community">
           <HeaderAuthSection />
         </Header>
       </div>

--- a/app/strategy-room/[seasonId]/applications/[applicationId]/page.tsx
+++ b/app/strategy-room/[seasonId]/applications/[applicationId]/page.tsx
@@ -97,7 +97,7 @@ export default function ApplicationDetailPage() {
       {/* 메인 콘텐츠 - data가 있을 때만 렌더링 */}
       {data && (
         <>
-          <Header title={isMe ? "내 프로필" : "프로필"} showPrevButton showHomeButton />
+          <Header title={isMe ? "내 프로필" : "프로필"} showPrevButton showHomeButton fallbackUrl={`/strategy-room/${seasonId}`} />
           <div className="flex flex-col px-[20px]">
             {/* 상단 요약 */}
             <div className="flex flex-col gap-[20px] border-b-[8px] border-gray-300 py-[20px]">

--- a/app/strategy-room/[seasonId]/applications/new/page.tsx
+++ b/app/strategy-room/[seasonId]/applications/new/page.tsx
@@ -346,7 +346,7 @@ function ApplicationNewContent() {
   if (isLoading) {
     return (
       <div className="flex min-h-screen flex-col">
-        <Header title="성적 공유" showPrevButton showHomeButton showBorder />
+        <Header title="성적 공유" showPrevButton showHomeButton showBorder fallbackUrl={`/strategy-room/${seasonId}`} />
         <div className="flex flex-1 items-center justify-center">
           <p className="text-gray-500">로딩 중...</p>
         </div>
@@ -363,7 +363,7 @@ function ApplicationNewContent() {
 
   return (
     <div className="flex min-h-screen flex-col">
-      <Header title="성적 공유" showPrevButton showHomeButton />
+      <Header title="성적 공유" showPrevButton showHomeButton fallbackUrl={`/strategy-room/${seasonId}`} />
       <ProgressBar currentStep={step === "university-selection" ? 2 : 1} totalSteps={2} />
 
       {/* Step 1: 성적 등록 */}

--- a/app/strategy-room/[seasonId]/applications/re-select-university/page.tsx
+++ b/app/strategy-room/[seasonId]/applications/re-select-university/page.tsx
@@ -204,7 +204,7 @@ function ApplicationEditContent() {
   if (isLoading) {
     return (
       <div className="flex min-h-screen flex-col">
-        <Header title="지망 대학 변경하기" showPrevButton showHomeButton />
+        <Header title="지망 대학 변경하기" showPrevButton showHomeButton fallbackUrl={`/strategy-room/${seasonId}`} />
         <div className="flex flex-1 items-center justify-center">
           <p className="text-gray-500">로딩 중...</p>
         </div>
@@ -215,7 +215,7 @@ function ApplicationEditContent() {
   if (error || !myApplication) {
     return (
       <div className="flex min-h-screen flex-col">
-        <Header title="지망 대학 변경하기" showPrevButton showHomeButton />
+        <Header title="지망 대학 변경하기" showPrevButton showHomeButton fallbackUrl={`/strategy-room/${seasonId}`} />
         <div className="flex flex-1 items-center justify-center">
           <p className="text-red-500">{error || "데이터를 불러올 수 없습니다."}</p>
         </div>
@@ -225,7 +225,7 @@ function ApplicationEditContent() {
 
   return (
     <div className="flex min-h-screen flex-col">
-      <Header title="지망 대학 변경하기" showPrevButton showHomeButton />
+      <Header title="지망 대학 변경하기" showPrevButton showHomeButton fallbackUrl={`/strategy-room/${seasonId}`} />
 
       <UniversitySelectionStep
         selectedUniversities={selectedUniversities}

--- a/app/strategy-room/[seasonId]/slots/[slotId]/page.tsx
+++ b/app/strategy-room/[seasonId]/slots/[slotId]/page.tsx
@@ -190,7 +190,7 @@ export default function SlotDetailPage() {
   if (error || !data) {
     return (
       <div className="flex min-h-screen flex-col">
-        <Header title="지원자 목록" showPrevButton showHomeButton showBorder />
+        <Header title="지원자 목록" showPrevButton showHomeButton showBorder fallbackUrl={`/strategy-room/${seasonId}`} />
         <div className="flex flex-1 items-center justify-center">
           <p className="text-error-red">{error || "데이터를 찾을 수 없습니다."}</p>
         </div>
@@ -208,7 +208,7 @@ export default function SlotDetailPage() {
   return (
     <div className="flex min-h-screen flex-col">
       {/* 상단 헤더 */}
-      <Header title="지원자 목록" showPrevButton showHomeButton />
+      <Header title="지원자 목록" showPrevButton showHomeButton fallbackUrl={`/strategy-room/${seasonId}`} />
 
       {/* 대학 정보 */}
       <section className="border-b border-gray-100 p-[20px]">

--- a/components/community/PostDetailPageClient.tsx
+++ b/components/community/PostDetailPageClient.tsx
@@ -90,7 +90,7 @@ export default function PostDetailPageClient({ postId }: PostDetailPageClientPro
   return (
     <div className="flex min-h-screen flex-col">
       <div className="sticky top-0 z-20 bg-white">
-        <Header showPrevButton showHomeButton showBorder>
+        <Header showPrevButton showHomeButton showBorder fallbackUrl="/community">
           {post && !isLoading ? <PostActionMenuButton post={post} /> : null}
         </Header>
       </div>

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -18,6 +18,7 @@ interface HeaderProps {
   searchQuery?: string;
   onSearchChange?: (query: string) => void;
   showBorder?: boolean;
+  fallbackUrl?: string; // 뒤로가기 히스토리 없을 때 이동할 경로
 }
 
 export default function Header({
@@ -30,6 +31,7 @@ export default function Header({
   searchQuery = "",
   onSearchChange,
   showBorder = false,
+  fallbackUrl,
 }: HeaderProps) {
   const [isSearchMode, setIsSearchMode] = useState(false);
 
@@ -51,6 +53,7 @@ export default function Header({
         onCancel={handleSearchCancel}
         showBorder={showBorder}
         showPrevButton={showPrevButton}
+        fallbackUrl={fallbackUrl}
       />
     );
   }
@@ -65,6 +68,7 @@ export default function Header({
       showSearchButton={showSearchButton}
       onSearchClick={handleSearchClick}
       showBorder={showBorder}
+      fallbackUrl={fallbackUrl}
     >
       {children}
     </NormalHeader>
@@ -78,14 +82,24 @@ function SearchHeader({
   onCancel,
   showBorder,
   showPrevButton,
+  fallbackUrl,
 }: {
   searchQuery: string;
   onSearchChange?: (query: string) => void;
   onCancel: () => void;
   showBorder: boolean;
   showPrevButton: boolean;
+  fallbackUrl?: string;
 }) {
   const router = useRouter();
+
+  const handleBack = () => {
+    if (window.history.length > 1) {
+      router.back();
+    } else if (fallbackUrl) {
+      router.replace(fallbackUrl); // push → replace: 현재 페이지를 히스토리에서 제거
+    }
+  };
 
   return (
     <header
@@ -93,7 +107,7 @@ function SearchHeader({
     >
       {showPrevButton && (
         <button
-          onClick={() => router.back()}
+          onClick={handleBack}
           className="flex h-[20px] w-[20px] flex-shrink-0 cursor-pointer items-center"
         >
           <PrevIcon size={14} />
@@ -133,6 +147,7 @@ function NormalHeader({
   showSearchButton,
   onSearchClick,
   showBorder,
+  fallbackUrl,
 }: {
   children?: React.ReactNode;
   title?: string;
@@ -142,8 +157,17 @@ function NormalHeader({
   showSearchButton: boolean;
   onSearchClick: () => void;
   showBorder: boolean;
+  fallbackUrl?: string;
 }) {
   const router = useRouter();
+
+  const handleBack = () => {
+    if (window.history.length > 1) {
+      router.back();
+    } else if (fallbackUrl) {
+      router.replace(fallbackUrl); // push → replace: 현재 페이지를 히스토리에서 제거
+    }
+  };
 
   return (
     <header
@@ -159,7 +183,7 @@ function NormalHeader({
           </Link>
         )}
         {showPrevButton && (
-          <button onClick={() => router.back()} className="flex h-[20px] w-[20px] cursor-pointer items-center">
+          <button onClick={handleBack} className="flex h-[20px] w-[20px] cursor-pointer items-center">
             <PrevIcon size={14} />
           </button>
         )}


### PR DESCRIPTION
## #️⃣ Issue Number
#225 
<!--- ex) #이슈번호, #이슈번호 -->

<br/>
<br/>

## 📝 요약(Summary)
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
<!--- 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- Header 컴포넌트에 fallbackUrl prop 추가
- 브라우저 히스토리 없을 때 fallback 경로로 이동하도록 개선
- window.history.length 체크하여 안전한 뒤로가기 구현

적용된 페이지 (7개):
- 커뮤니티: 국가 상세, 대학 상세, 게시글 상세
- 전략실: 슬롯 상세, 지원서 상세, 지원서 작성, 대학 재선택

사용자가 외부 링크로 직접 접근 시 상위 페이지로 이동 가능하도록 개선
<br/>
<br/>

## 🛠️ PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
