### PR TITLE
feat: 지원자가 없는 경우 모든 대학 default로 보이기

### DIFF
--- a/components/strategy-room/StrategyRoomClient.tsx
+++ b/components/strategy-room/StrategyRoomClient.tsx
@@ -17,12 +17,15 @@ import { getSeasonSlots, getMyApplication } from "@/lib/api/slot";
 import { handleApiError } from "@/lib/utils/apiError";
 import { SeasonSlotsResponse, MyApplicationResponse } from "@/types/slot";
 
-type TabType = "지망한 대학" | "지원자가 있는 대학" | "모든 대학";
+const TAB_OPTIONS = ["지망한 대학", "지원자가 있는 대학", "모든 대학"] as const;
+type TabType = (typeof TAB_OPTIONS)[number];
 
 export default function StrategyRoomClient() {
   const params = useParams();
   const router = useRouter();
   const searchParams = useSearchParams();
+  const tabParam = searchParams.get("tab");
+  const tabFromUrl = TAB_OPTIONS.find((tab) => tab === tabParam) ?? null;
   const seasonId = params.seasonId as string;
   const isDesktop = useIsDesktop();
 
@@ -31,12 +34,7 @@ export default function StrategyRoomClient() {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  // URL query parameter에서 초기 탭 상태 읽기
-  const tabParam = searchParams.get("tab") as TabType;
-
-  const [selectedTab, setSelectedTab] = useState<TabType>(
-    tabParam && ["지망한 대학", "지원자가 있는 대학", "모든 대학"].includes(tabParam) ? tabParam : "지원자가 있는 대학"
-  );
+  const [selectedTab, setSelectedTab] = useState<TabType>(tabFromUrl ?? "모든 대학");
   const [searchQuery, setSearchQuery] = useState("");
   const [isSearchDialogOpen, setIsSearchDialogOpen] = useState(false);
 
@@ -81,13 +79,32 @@ export default function StrategyRoomClient() {
     }
   }, [seasonId]);
 
-  // hasApplied가 true이고 URL에 tab 파라미터가 없으면 "지망한 대학" 탭으로 자동 설정
+  const applicantSlotCount = useMemo(() => {
+    if (!data) return 0;
+    return data.slots.filter((slot) => slot.choiceCount !== null && slot.choiceCount >= 1).length;
+  }, [data]);
+
+  const hasApplicantSlots = applicantSlotCount > 0;
+
+  // URL -> 성적 공유 여부 -> 지원자 수 순으로 초기 탭 결정
   useEffect(() => {
-    const tabParam = searchParams.get("tab");
-    if (data?.hasApplied && !tabParam) {
-      setSelectedTab("지망한 대학");
+    if (tabFromUrl) {
+      setSelectedTab(tabFromUrl);
+      return;
     }
-  }, [data?.hasApplied, searchParams]);
+
+    if (data?.hasApplied) {
+      setSelectedTab("지망한 대학");
+      return;
+    }
+
+    if (hasApplicantSlots) {
+      setSelectedTab("지원자가 있는 대학");
+      return;
+    }
+
+    setSelectedTab("모든 대학");
+  }, [tabFromUrl, data?.hasApplied, hasApplicantSlots]);
 
   // 필터링된 슬롯 목록 (탭 + 검색)
   const filteredSlots = useMemo(() => {
@@ -155,7 +172,7 @@ export default function StrategyRoomClient() {
 
   const tabCounts = {
     "지망한 대학": !hasSharedGrade ? 0 : myChosenUniversities.length,
-    "지원자가 있는 대학": data.slots.filter((slot) => slot.choiceCount !== null && slot.choiceCount >= 1).length,
+    "지원자가 있는 대학": applicantSlotCount,
     "모든 대학": data.slots.length,
   };
 
@@ -220,7 +237,7 @@ export default function StrategyRoomClient() {
 
           <section className="flex flex-col gap-[12px] lg:flex-row lg:items-center lg:justify-between">
             <Tabs
-              tabs={["지망한 대학", "지원자가 있는 대학", "모든 대학"] as const}
+              tabs={TAB_OPTIONS}
               selectedTab={selectedTab}
               onTabChange={handleTabChange}
               counts={tabCounts}


### PR DESCRIPTION
<!--- Pull Request title = 커밋 메시지와 동일 / 해당 이슈를 close 하지 않을 경우, footer #이슈 번호 제외  -->

## #️⃣ Issue Number
#252 
<br/>
<br/>

## 📝 요약(Summary)

- 성적 공유 탭 초기화 우선순위를 재정렬하여 URL `tab` 파라미터 → 성적 공유 완료 여부 → 지원자 존재 여부 → 전체 보기 순으로 일관되게 적용했습니다.
- `TAB_OPTIONS` 상수와 타입을 한 곳에서 관리하게 변경하고, 탭 카운트 계산을 재사용하여 중복 필터링을 줄였습니다.
- 지원자가 없는 시즌에서 “모든 대학” 탭이 기본으로 열리고, 뒤로 가기/공유 링크는 원하는 탭으로 즉시 복원됩니다.

- **URL 우선 적용**: 히스토리/공유 링크 복원, 뒤로 가기 시 동일 탭을 보여주기 위해 `tabParam`이 있으면 첫 렌더부터 바로 반영하도록 했습니다.
- **단일 이펙트에서 fallback 처리**: URL이 없는 경우에만 성적 공유 여부와 지원자 존재 여부로 결정하도록 해서 기본값 로직이 한곳에 모여 유지보수가 쉽습니다.
- **상수 기반 타입**: 탭 문자열을 여러 곳에서 따로 관리하면 변경 시 누락 위험이 있으므로 `TAB_OPTIONS`와 타입을 같은 소스에서 파생시켰습니다.
- **카운트 재사용**: 지원자 수 계산을 한 번만 수행해 탭 배지 숫자와 초기 탭 판단이 동일한 데이터를 바라보게 하여 버그 가능성을 낮췄습니다.
<br/>
<br/>

## 🛠️ PR 유형
어떤 변경 사항이 있나요?

- [x] 버그 수정
- [x] 코드 리팩토링
- [ ] 새로운 기능 추가
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

<br/>
<br/>